### PR TITLE
Ignore .bundle/ and vendor/ files from git and Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.bundle/
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /log/
 /coverage/
+/.bundle
+/vendor


### PR DESCRIPTION
We don't want to use any Gems installed for local development inside the Docker container.

```
$  bundle 
Warning: the running version of Bundler is older than the version that created the lockfile. We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/..........
Fetching version metadata from https://rubygems.org/..


Your user account isn't allowed to install to the system Rubygems.
  You can cancel this installation and run:

      bundle install --path vendor/bundle

  to install the gems into ./vendor/bundle/, or you can enter your password
  and install the bundled gems to Rubygems using sudo.

  Password: 
$ bundle --path vendor/bundle
Warning: the running version of Bundler is older than the version that created the lockfile. We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/..........
Fetching version metadata from https://rubygems.org/..
Installing rake 11.2.2
Installing i18n 0.7.0
Using json 1.8.3
Installing minitest 5.9.0
Installing thread_safe 0.3.5
Installing addressable 2.3.8
Installing safe_yaml 1.0.4
Installing daemons 1.2.3
Installing diff-lcs 1.2.5
Installing docile 1.1.5
Installing mixlib-log 1.6.0
Installing eventmachine 1.2.0.1 with native extensions
Installing rack 1.6.4
Installing rspec-support 3.5.0
Installing simplecov-html 0.10.0
Installing tilt 2.0.5
Using bundler 1.11.2
Installing tzinfo 1.2.2
Installing crack 0.4.2
Installing etcd 0.3.0
Installing rack-protection 1.5.3
Installing thin 1.7.0 with native extensions
Installing rspec-core 3.5.2
Installing rspec-expectations 3.5.0
Installing rspec-mocks 3.5.0
Installing simplecov 0.10.0
Installing activesupport 4.2.6
Installing webmock 1.21.0
Installing sinatra 1.4.7
Installing rspec 3.5.0
Installing mutations 0.7.2
Bundle complete! 8 Gemfile dependencies, 31 gems now installed.
Bundled gems are installed into ./vendor/bundle.

$ docker build -t kontena-ipam . && docker run --rm --name kontena-ipam --net host -v /run/docker/plugins:/run/docker/plugins kontena-ipam
Sending build context to Docker daemon 23.08 MB
...
env: can't execute 'ruby2.3': No such file or directory
```
