### PR TITLE
Use first host address as gw in each network

### DIFF
--- a/app/models/address_pool.rb
+++ b/app/models/address_pool.rb
@@ -5,8 +5,9 @@ class AddressPool
   etcd_path '/kontena/ipam/pools/:id'
   json_attr :subnet, type: IPAddr
   json_attr :iprange, type: IPAddr, omitnil: true
+  json_attr :gateway, type: IPAddr
 
-  attr_accessor :id, :subnet, :iprange
+  attr_accessor :id, :subnet, :iprange, :gateway
 
   # Return currently reserved subnets
   #
@@ -22,6 +23,8 @@ class AddressPool
   # @see Subnet
   def create!
     Subnet.reserve(@subnet)
+    # use the first host address as gateway
+    @gateway = allocation_range.first(2)[1]
     super
     Address.mkdir(@id)
   end
@@ -71,7 +74,7 @@ class AddressPool
   #
   # @return [IPSet]
   def reserved_addresses
-    IPSet.new(list_addresses.map{|a| a.address.to_host })
+    IPSet.new(list_addresses.map{|a| a.address.to_host } + [@gateway])
   end
 
   # Compute available addresses for allocation within pool

--- a/plugin.rb
+++ b/plugin.rb
@@ -90,7 +90,7 @@ class IpamPlugin < Sinatra::Application
     json(
       'PoolID' => pool.id,
       'Pool' => pool.subnet.to_cidr,
-      'Data' => {},
+      'Data' => {'com.docker.network.gateway' => pool.gateway.to_cidr},
     )
   end
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -79,39 +79,50 @@ describe IpamPlugin do
     end
 
     it 'accepts with only the required parameters' do
-      expect(AddressPools::Request).to receive(:run!).with(policy: policy, network: 'test', subnet: nil, iprange: nil, ipv6: nil).and_return(AddressPool.new('test', subnet: IPAddr.new('10.80.0.0/24')))
+      expect(AddressPools::Request)
+        .to receive(:run!)
+        .with(policy: policy, network: 'test', subnet: nil, iprange: nil, ipv6: nil)
+        .and_return(AddressPool.new('test', subnet: IPAddr.new('10.80.0.0/24'), gateway: IPAddr.new('10.80.0.1/24')))
 
       data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test'}}
 
       expect(last_response).to be_ok, last_response.errors
-      expect(data).to eq('PoolID' => 'test', 'Pool' => '10.80.0.0/24', 'Data' => {})
+      expect(data).to eq('PoolID' => 'test', 'Pool' => '10.80.0.0/24', 'Data' => { 'com.docker.network.gateway' => '10.80.0.1/24'})
     end
 
     it 'accepts with an empty optional param' do
-      expect(AddressPools::Request).to receive(:run!).with(policy: policy, network: 'test', subnet: '', iprange: '', ipv6: nil).and_return(AddressPool.new('test', subnet: IPAddr.new('10.80.0.0/24')))
+      expect(AddressPools::Request)
+        .to receive(:run!)
+        .with(policy: policy, network: 'test', subnet: '', iprange: '', ipv6: nil)
+        .and_return(AddressPool.new('test', subnet: IPAddr.new('10.80.0.0/24'), gateway: IPAddr.new('10.80.0.1/24')))
 
       data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test'}, 'Pool' => '', 'SubPool' => ''}
 
       expect(last_response).to be_ok, last_response.errors
-      expect(data).to eq('PoolID' => 'test', 'Pool' => '10.80.0.0/24', 'Data' => {})
+      expect(data).to eq('PoolID' => 'test', 'Pool' => '10.80.0.0/24', 'Data' => {'com.docker.network.gateway' => '10.80.0.1/24'})
     end
 
     it 'accepts with an optional pool' do
-      expect(AddressPools::Request).to receive(:run!).with(policy: policy, network: 'kontena', subnet: '10.81.0.0/16', iprange: nil, ipv6: nil).and_return(AddressPool.new('kontena', subnet: IPAddr.new('10.80.0.0/16')))
+      expect(AddressPools::Request)
+        .to receive(:run!).with(policy: policy, network: 'kontena', subnet: '10.81.0.0/16', iprange: nil, ipv6: nil)
+        .and_return(AddressPool.new('kontena', subnet: IPAddr.new('10.81.0.0/16'), gateway: IPAddr.new('10.81.0.1/16')))
 
       data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'kontena'}, 'Pool' => '10.81.0.0/16'}
 
       expect(last_response).to be_ok, last_response.errors
-      expect(data).to eq('PoolID' => 'kontena', 'Pool' => '10.80.0.0/16', 'Data' => {})
+      expect(data).to eq('PoolID' => 'kontena', 'Pool' => '10.81.0.0/16', 'Data' => {'com.docker.network.gateway' => '10.81.0.1/16'})
     end
 
     it 'accepts with an optional iprange' do
-      expect(AddressPools::Request).to receive(:run!).with(policy: policy, network: 'kontena', subnet: '10.81.0.0/16', iprange: '10.81.127.0/17', ipv6: nil).and_return(AddressPool.new('kontena', subnet: IPAddr.new('10.80.0.0/16')))
+      expect(AddressPools::Request)
+        .to receive(:run!)
+        .with(policy: policy, network: 'kontena', subnet: '10.81.0.0/16', iprange: '10.81.127.0/17', ipv6: nil)
+        .and_return(AddressPool.new('kontena', subnet: IPAddr.new('10.80.0.0/16'), gateway: IPAddr.new('10.81.0.1/16')))
 
       data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'kontena'}, 'Pool' => '10.81.0.0/16', 'SubPool' => '10.81.127.0/17'}
 
       expect(last_response).to be_ok, last_response.errors
-      expect(data).to eq('PoolID' => 'kontena', 'Pool' => '10.80.0.0/16', 'Data' => {})
+      expect(data).to eq('PoolID' => 'kontena', 'Pool' => '10.80.0.0/16', 'Data' => {'com.docker.network.gateway' => '10.81.0.1/16'})
     end
   end
 


### PR DESCRIPTION
When allocating the address pool, use first network address as the gateway for the network.
