### PR TITLE
Reserved addresses as parameter for cleanup script

### DIFF
--- a/app/address_cleanup.rb
+++ b/app/address_cleanup.rb
@@ -10,20 +10,22 @@ class AddressCleanup
   include Logging
   include NodeHelper
 
-  def initialize(node_id = nil)
-    @node = node_id || node
+  # @param node_id [String]
+  # @param reserver_addresses [Array<String>]
+  def initialize(reserved_addresses = [])
+    @node = node
+    @reserved_addresses = reserved_addresses.map { |a| IPAddr.new(a).to_host }
   end
 
   def cleanup
     info "starting cleanup routine"
-    known_addresses = local_addresses
-    debug "locally known addresses: #{known_addresses}"
+    debug "locally known addresses: #{@reserved_addresses.size}"
     AddressPool.list.each { |pool|
       debug "checking pool: #{pool.id}"
       pool.list_addresses.each { |address|
         debug "checking address: #{address.address.to_host}..."
         if address.node == @node
-          if known_addresses.include?(address.address.to_host) || pool.gateway.to_host == address.address.to_host
+          if @reserved_addresses.include?(address.address.to_host) || pool.gateway.to_host == address.address.to_host
             debug '..still in use or gateway, skipping.'
             next
           else
@@ -40,27 +42,4 @@ class AddressCleanup
     info "cleanup done"
   end
 
-
-  # Collect all known addresses of local docker networks using this ipam
-  def local_addresses
-    local_addresses = []
-
-    Docker::Network.all.each { |network|
-      debug "checking network #{network.json}"
-      nw_json = network.json
-      if nw_json.dig('IPAM', 'Driver') == 'kontena-ipam'
-        debug "Kontena ipam managed network, checking containers (#{nw_json.dig('Containers').size})"
-        nw_json.dig('Containers').each { |c, value|
-          debug "container: #{c}"
-          debug "value: #{value}"
-          address = IPAddr.new(value.dig('IPv4Address'))
-          local_addresses << address if address
-        }
-      end
-
-      local_addresses.map!{ |a| a.to_host }
-    }
-    info "Collected #{local_addresses.size} local addresses managed by Kontena ipam driver"
-    local_addresses
-  end
 end

--- a/app/address_cleanup.rb
+++ b/app/address_cleanup.rb
@@ -10,22 +10,31 @@ class AddressCleanup
   include Logging
   include NodeHelper
 
-  # @param node_id [String]
-  # @param reserver_addresses [Array<String>]
-  def initialize(reserved_addresses = [])
+  def initialize()
     @node = node
-    @reserved_addresses = reserved_addresses.map { |a| IPAddr.new(a).to_host }
   end
 
-  def cleanup
-    info "starting cleanup routine"
-    debug "locally known addresses: #{@reserved_addresses.size}"
+  def cleanup_docker_networks
+    cleanup(local_docker_known_addresses)
+  end
+
+  def cleanup_known_addresses(reserved_addresses = [])
+    cleanup(reserved_addresses.map { |a| IPAddr.new(a).to_host })
+  end
+
+  private
+
+  def cleanup(reserved_addresses)
+    info "starting cleanup routine for node: #{@node}"
+    debug "locally known addresses: #{reserved_addresses.size}"
     AddressPool.list.each { |pool|
       debug "checking pool: #{pool.id}"
       pool.list_addresses.each { |address|
         debug "checking address: #{address.address.to_host}..."
+        debug "address.node: #{address.node.inspect}"
+        debug "node: #{@node.inspect}"
         if address.node == @node
-          if @reserved_addresses.include?(address.address.to_host) || pool.gateway.to_host == address.address.to_host
+          if reserved_addresses.include?(address.address.to_host) || pool.gateway.to_host == address.address.to_host
             debug '..still in use or gateway, skipping.'
             next
           else
@@ -41,5 +50,28 @@ class AddressCleanup
     }
     info "cleanup done"
   end
+
+  # Collect all known addresses of local docker networks using this ipam
+   def local_docker_known_addresses
+    local_addresses = []
+
+    Docker::Network.all.each { |network|
+      debug "checking network #{network.json}"
+      nw_json = network.json
+      if nw_json.dig('IPAM', 'Driver') == 'kontena-ipam'
+        debug "Kontena ipam managed network, checking containers (#{nw_json.dig('Containers').size})"
+        nw_json.dig('Containers').each { |c, value|
+          debug "container: #{c}"
+          debug "value: #{value}"
+          address = IPAddr.new(value.dig('IPv4Address'))
+          local_addresses << address if address
+        }
+      end
+
+      local_addresses.map!{ |a| a.to_host }
+    }
+    info "Collected #{local_addresses.size} local Docker network addresses managed by Kontena ipam driver"
+    local_addresses
+   end
 
 end

--- a/bin/kontena-ipam-cleanup
+++ b/bin/kontena-ipam-cleanup
@@ -12,7 +12,7 @@ Logging.initialize_logger(STDERR, log_level)
 EtcdModel.etcd = EtcdClient.new(ENV)
 
 # TODO: Addresses::Cleanup
-cleaner = AddressCleanup.new(ARGV)
-cleaner.cleanup
+cleaner = AddressCleanup.new
+cleaner.cleanup_known_addresses(ARGV)
 
 AddressPools::Cleanup.run!

--- a/bin/kontena-ipam-cleanup
+++ b/bin/kontena-ipam-cleanup
@@ -12,7 +12,7 @@ Logging.initialize_logger(STDERR, log_level)
 EtcdModel.etcd = EtcdClient.new(ENV)
 
 # TODO: Addresses::Cleanup
-cleaner = AddressCleanup.new
+cleaner = AddressCleanup.new(ARGV)
 cleaner.cleanup
 
 AddressPools::Cleanup.run!

--- a/spec/address_cleanup_spec.rb
+++ b/spec/address_cleanup_spec.rb
@@ -4,9 +4,6 @@ describe AddressCleanup do
 
   include Rack::Test::Methods
 
-  let(:subject) do
-    described_class.new('1')
-  end
 
   describe '#initialize' do
     it 'fallbacks to NodeHelper to get node id' do
@@ -14,32 +11,6 @@ describe AddressCleanup do
 
       cleaner = described_class.new
       expect(cleaner.instance_variable_get('@node')).to eq('somenode')
-    end
-  end
-
-  describe '#local_addresses' do
-    it 'collects all docker address' do
-      expect(Docker::Network).to receive(:all).and_return(
-        [
-          double(json: {
-            "IPAM" => {
-              "Driver" => "kontena-ipam"
-            },
-            "Containers" => { "foo" => {"IPv4Address" => "10.80.0.11/24"}}
-            }
-          ),
-          double(json: {
-            "IPAM" => {
-              "Driver" => "default"
-            },
-            "Containers" => { "bar" => {"IPv4Address" => "10.85.0.11/24"}}
-            }
-          )
-        ]
-      )
-
-      known_addresses = subject.local_addresses
-      expect(known_addresses.size).to eq 1
     end
   end
 
@@ -57,7 +28,8 @@ describe AddressCleanup do
     end
 
     it 'removes only unused addresses' do
-      expect(subject).to receive(:local_addresses).and_return([IPAddr.new('10.80.1.111/24').to_host])
+      expect_any_instance_of(NodeHelper).to receive(:node).and_return('1')
+      subject = described_class.new(['10.80.1.111/24'])
 
       subject.cleanup
 


### PR DESCRIPTION
Agent moving back to weave managed network mode (and possibly in future different network models) the cleanup routine cannot figure out the locally used addresses by itself. Thus a change to give the locally known addresses as attributes for the cleanup script.