### PR TITLE
Fix policy allocate_address to always randomize

### DIFF
--- a/app/mutations/addresses/request.rb
+++ b/app/mutations/addresses/request.rb
@@ -63,17 +63,13 @@ module Addresses
     # @raise AddressPool::Full
     # @return [Address] reserved address
     def request_dynamic
-      available = @pool.available_addresses.first(100).to_a
-
-      info "Allocate dynamic address in pool=#{@pool.id} from range=#{@pool.allocation_range} with available=#{available.size}#{available.size >= 100 ? '+' : ''} addresses"
-
       # allocate
-      unless allocate_address = policy.allocate_address(available)
+      unless ipaddr = policy.allocate_address(@pool)
         raise AddressPool::Full, "No addresses available for allocation in pool #{@pool}"
       end
 
       # reserve
-      return @pool.create_address(allocate_address)
+      return @pool.create_address(ipaddr)
     end
   end
 end

--- a/app/policy.rb
+++ b/app/policy.rb
@@ -8,6 +8,8 @@
 # @attr_reader [IPAddr] supernet CIDR range for allocating subnets
 # @attr_reader [Integer] subnet_length desired subnet length
 class Policy
+  include Logging
+
   # Allocate subnets from within this network
   SUPERNET = IPAddr.new('10.80.0.0/12')
 
@@ -43,13 +45,19 @@ class Policy
   # Allocate an IP address from within the given set of available addresses.
   # Returns nil if no available addresses
   #
-  # @param addresses [Array<IPAddr>] available host addresses
+  # @param pol [AddressPool] pool to allocate from
   # @return [IPAddr] or nil
-  def allocate_address(addresses)
-    if addresses.empty?
-      nil
+  def allocate_address(pool)
+    available = pool.available_addresses.first(100).to_a
+
+    if available.empty?
+      warn "Address pool=#{pool.id} allocates range=#{pool.allocation_range} with no available addresses"
+
+      return nil
     else
-      addresses[rand(0...addresses.size)]
+      info "Address pool=#{pool.id} allocates from range=#{pool.allocation_range} with available=#{available.size}#{available.size >= 100 ? '+' : ''} addresses"
+
+      return available[rand(0...available.size)]
     end
   end
 end

--- a/app/policy.rb
+++ b/app/policy.rb
@@ -57,7 +57,7 @@ class Policy
     else
       info "Address pool=#{pool.id} allocates from range=#{pool.allocation_range} with available=#{available.size}#{available.size >= 100 ? '+' : ''} addresses"
 
-      return available[rand(0...available.size)]
+      return available.sample
     end
   end
 end

--- a/app/policy.rb
+++ b/app/policy.rb
@@ -48,10 +48,8 @@ class Policy
   def allocate_address(addresses)
     if addresses.empty?
       nil
-    elsif addresses.size > 100
-      addresses[rand(0..100)]
     else
-      addresses[0]
+      addresses[rand(0...addresses.size)]
     end
   end
 end

--- a/app/policy.rb
+++ b/app/policy.rb
@@ -45,7 +45,7 @@ class Policy
   # Allocate an IP address from within the given set of available addresses.
   # Returns nil if no available addresses
   #
-  # @param pol [AddressPool] pool to allocate from
+  # @param pool [AddressPool] pool to allocate from
   # @return [IPAddr] or nil
   def allocate_address(pool)
     available = pool.available_addresses.first(100).to_a

--- a/lib/ipaddr_helpers.rb
+++ b/lib/ipaddr_helpers.rb
@@ -184,6 +184,9 @@ class IPAddr
 
     # Return address within subnet.
     #
+    # @param i [Integer] offset within subnet
+    # @raise ArgumentError address outside of subnet
+    # @return [IPAddr] address with host bits set and subnet mask
     def [](i)
       raise ArgumentError, "IP #{i} outside of subnet #{inspect}" if i > _hostmask
 

--- a/lib/ipaddr_helpers.rb
+++ b/lib/ipaddr_helpers.rb
@@ -182,6 +182,14 @@ class IPAddr
       @addr & _hostmask
     end
 
+    # Return address within subnet.
+    #
+    def [](i)
+      raise ArgumentError, "IP #{i} outside of subnet #{inspect}" if i > _hostmask
+
+      self | i
+    end
+
     # Enumerate the subnet addresses within this network.
     #
     # Optionally skip the first offset addresses.

--- a/lib/ipset.rb
+++ b/lib/ipset.rb
@@ -11,10 +11,16 @@ class IPSet
     @addrs = addrs.sort
   end
 
+  # Number of addresses in set
+  #
+  # @return [Integer]
   def length
     @addrs.length
   end
 
+  # Add new address to set
+  #
+  # @param addr [IPAddr]
   def add!(addr)
     @addrs.push(addr)
     @addrs.sort!

--- a/lib/ipset.rb
+++ b/lib/ipset.rb
@@ -15,6 +15,11 @@ class IPSet
     @addrs.length
   end
 
+  def add!(addr)
+    @addrs.push(addr)
+    @addrs.sort!
+  end
+
   # Search for addrs contained within the given networks, or networks containing the given addr
   def search(addr)
     @addrs.each do |a|

--- a/spec/ipaddr_spec.rb
+++ b/spec/ipaddr_spec.rb
@@ -120,6 +120,21 @@ describe IPAddr do
       expect(subject.broadcast).to be_broadcast
     end
 
+    describe '#[]' do
+      it 'returns the correct IP' do
+        expect(subject[0].to_s).to eq '192.0.2.0'
+        expect(subject[1].to_s).to eq '192.0.2.1'
+        expect(subject[2].to_s).to eq '192.0.2.2'
+        expect(subject[254].to_s).to eq '192.0.2.254'
+        expect(subject[255].to_s).to eq '192.0.2.255'
+      end
+
+      it 'raises on invalid offset' do
+        expect{subject[256]}.to raise_error(ArgumentError)
+        expect{subject[256 + 1]}.to raise_error(ArgumentError)
+      end
+    end
+
     it 'lists the host addresses' do
       hosts = subject.hosts
 

--- a/spec/ipset_spec.rb
+++ b/spec/ipset_spec.rb
@@ -1,6 +1,32 @@
 require_relative '../lib/ipset'
 
 describe IPSet do
+  it 'includes an added address' do
+    subject = described_class.new([])
+    subject.add! IPAddr.new('192.0.2.1')
+
+    expect(subject.length).to eq 1
+    expect(subject).to include IPAddr.new('192.0.2.1')
+  end
+
+  it 'also includes an added address' do
+    subject = described_class.new([IPAddr.new('192.0.2.1')])
+    subject.add! IPAddr.new('192.0.2.2')
+
+    expect(subject.length).to eq 2
+    expect(subject).to include IPAddr.new('192.0.2.1')
+    expect(subject).to include IPAddr.new('192.0.2.2')
+  end
+
+  it 'also includes an added address in reverse order' do
+    subject = described_class.new([IPAddr.new('192.0.2.2')])
+    subject.add! IPAddr.new('192.0.2.1')
+
+    expect(subject.length).to eq 2
+    expect(subject).to include IPAddr.new('192.0.2.1')
+    expect(subject).to include IPAddr.new('192.0.2.2')
+  end
+
   context 'for a full subnet' do
     let :subject do
       described_class.new((1..254).map { |i| IPAddr.new("192.0.2.#{i}")})

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -18,54 +18,59 @@ describe Policy do
   end
 
   context 'using the 10.80.0.0/12 supernet' do
-    let :policy do
+    subject do
       Policy.new(
         'KONTENA_IPAM_SUPERNET' => '10.80.0.0/12',
         'KONTENA_IPAM_SUBNET_LENGTH' => '24',
       )
     end
 
-    it 'allocates consecutive subnet' do
-      reserved = IPSet.new([
-        IPAddr.new('10.80.0.64/28'),
-      ])
+    describe '#allocatable_subnets' do
+      it 'allocates consecutive subnet' do
+        reserved = IPSet.new([
+          IPAddr.new('10.80.0.64/28'),
+        ])
 
-      expect(policy.allocatable_subnets(reserved).take(3)).to eq [
-          IPAddr.new('10.80.1.0/24'),
-          IPAddr.new('10.80.2.0/24'),
-          IPAddr.new('10.80.3.0/24'),
-      ]
+        expect(subject.allocatable_subnets(reserved).take(3)).to eq [
+            IPAddr.new('10.80.1.0/24'),
+            IPAddr.new('10.80.2.0/24'),
+            IPAddr.new('10.80.3.0/24'),
+        ]
+      end
+
+      it 'allocates after sparse subnets' do
+        expect(subject.allocatable_subnets(IPSet.new([
+          IPAddr.new('10.80.0.64/26'),
+          IPAddr.new('10.80.0.128/26'),
+        ])).first).to eq IPAddr.new('10.80.1.0/24')
+      end
+
+      it 'allocates after mixed subnets' do
+        expect(subject.allocatable_subnets(IPSet.new([
+          IPAddr.new('10.80.0.0/22'),
+          IPAddr.new('10.80.3.64/26'),
+        ])).first).to eq IPAddr.new('10.80.4.0/24')
+      end
+
+      it 'allocates in between subnets' do
+        expect(subject.allocatable_subnets(IPSet.new([
+          IPAddr.new('10.80.0.0/23'),
+          IPAddr.new('10.80.4.0/23'),
+        ])).first).to eq IPAddr.new('10.80.2.0/24')
+      end
+
+      it 'allocates to the very end' do
+        expect(subject.allocatable_subnets(IPSet.new([])).to_a.last).to eq IPAddr.new('10.95.255.0/24')
+      end
+
+      it 'returns nil if the supernet is full' do
+        reserved_subnets = (80..95).map {|x| IPAddr.new("10.#{x}.0.0/16") }
+
+        expect(subject.allocatable_subnets(IPSet.new(reserved_subnets)).first).to be_nil
+      end
     end
 
-    it 'allocates after sparse subnets' do
-      expect(policy.allocatable_subnets(IPSet.new([
-        IPAddr.new('10.80.0.64/26'),
-        IPAddr.new('10.80.0.128/26'),
-      ])).first).to eq IPAddr.new('10.80.1.0/24')
-    end
 
-    it 'allocates after mixed subnets' do
-      expect(policy.allocatable_subnets(IPSet.new([
-        IPAddr.new('10.80.0.0/22'),
-        IPAddr.new('10.80.3.64/26'),
-      ])).first).to eq IPAddr.new('10.80.4.0/24')
-    end
-
-    it 'allocates in between subnets' do
-      expect(policy.allocatable_subnets(IPSet.new([
-        IPAddr.new('10.80.0.0/23'),
-        IPAddr.new('10.80.4.0/23'),
-      ])).first).to eq IPAddr.new('10.80.2.0/24')
-    end
-
-    it 'allocates to the very end' do
-      expect(policy.allocatable_subnets(IPSet.new([])).to_a.last).to eq IPAddr.new('10.95.255.0/24')
-    end
-
-    it 'returns nil if the supernet is full' do
-      reserved_subnets = (80..95).map {|x| IPAddr.new("10.#{x}.0.0/16") }
-
-      expect(policy.allocatable_subnets(IPSet.new(reserved_subnets)).first).to be_nil
     end
   end
 end


### PR DESCRIPTION
#55 optimized the address allocation by only allocating from the first 100 available addresses, but did not fix the `Policy#allocate_address` subnet logic, which meant that the IPAM would always allocate the first available address.

* Implement `IPAddr[...]` and `IPSet.add!` helpers for use in specs
* Move the entire address allocation implementation into the Policy class
* Fix the Policy to always allocate randomly from the first 100 available addresses

This should help minimize allocation conflicts between concurrently allocating nodes.

## Testing

```
core@coreos-dev-02 ~ $ docker run --net kontena -it debian:jessie ip addr show dev ethwe0
18: ethwe0@if19: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1410 qdisc noqueue state UP group default 
    link/ether 26:da:36:7e:2a:0a brd ff:ff:ff:ff:ff:ff
    inet 10.81.128.16/16 scope global ethwe0
       valid_lft forever preferred_lft forever
    inet6 fe80::24da:36ff:fe7e:2a0a/64 scope link tentative 
       valid_lft forever preferred_lft forever
core@coreos-dev-02 ~ $ docker run --net kontena -it debian:jessie ip addr show dev ethwe0
22: ethwe0@if23: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1410 qdisc noqueue state UP group default 
    link/ether 3e:26:ab:b7:86:38 brd ff:ff:ff:ff:ff:ff
    inet 10.81.128.81/16 scope global ethwe0
       valid_lft forever preferred_lft forever
    inet6 fe80::3c26:abff:feb7:8638/64 scope link tentative 
       valid_lft forever preferred_lft forever
core@coreos-dev-02 ~ $ docker run --net kontena -it debian:jessie ip addr show dev ethwe0
26: ethwe0@if27: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1410 qdisc noqueue state UP group default 
    link/ether 4e:48:f8:be:47:29 brd ff:ff:ff:ff:ff:ff
    inet 10.81.128.2/16 scope global ethwe0
       valid_lft forever preferred_lft forever
    inet6 fe80::4c48:f8ff:febe:4729/64 scope link tentative 
       valid_lft forever preferred_lft forever
core@coreos-dev-02 ~ $ docker run --net kontena -it debian:jessie ip addr show dev ethwe0
30: ethwe0@if31: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1410 qdisc noqueue state UP group default 
    link/ether 4e:09:40:a0:3d:58 brd ff:ff:ff:ff:ff:ff
    inet 10.81.128.42/16 scope global ethwe0
       valid_lft forever preferred_lft forever
    inet6 fe80::4c09:40ff:fea0:3d58/64 scope link tentative 
       valid_lft forever preferred_lft forever
```