### PR TITLE
Fix travis repo for deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ deploy:
     on:
       tags: true
       rvm: 2.3.1
-      repo: kontena/kontena-docker-ipam-plugin
+      repo: kontena/kontena-ipam


### PR DESCRIPTION
> Skipping a deployment with the script provider because this repo's name does not match one specified in .travis.yml's deploy.on.repo: kontena/kontena-docker-ipam-plugin