### PR TITLE
Fix miscellaneous spec bugs, improvements

### DIFF
--- a/app/models/address_pool.rb
+++ b/app/models/address_pool.rb
@@ -127,7 +127,7 @@ class AddressPool
 
   # Compute available addresses for allocation within pool
   #
-  # @return [Enumerator<IPAddr>]
+  # @return [Enumerator<IPAddr>] with subnet mask
   def available_addresses
     @subnet.hosts(range: allocation_range, exclude: reserved_addresses)
   end

--- a/app/policy.rb
+++ b/app/policy.rb
@@ -46,7 +46,7 @@ class Policy
   # Returns nil if no available addresses
   #
   # @param pool [AddressPool] pool to allocate from
-  # @return [IPAddr] or nil
+  # @return [IPAddr, nil] with subnet mask
   def allocate_address(pool)
     available = pool.available_addresses.first(100).to_a
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -54,8 +54,8 @@ class IpamPlugin < Sinatra::Application
 
     begin
       params.merge! JSON.parse(body)
-    rescue JSON::JSONError => error
-      halt 400, "JSON parse error: #{error.message}"
+    rescue => error
+      halt 400, "Invalid request body #{error.class}: #{error.message}"
     end
   end
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -20,7 +20,9 @@ describe IpamPlugin do
     subject
   end
 
-  def api_post(url, params = {}, expect_status: 200)
+  # @param url [String]
+  # @param params [Hash, nil] request body JSON object
+  def api_post(url, params, expect_status: 200)
     if params.nil?
       post url
     else

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -28,24 +28,18 @@ describe IpamPlugin do
     end
 
     expect(last_response.status).to eq(expect_status), last_response.errors
+    expect(last_response.content_type).to eq 'application/json'
 
-    if last_response.content_type == 'application/json'
-      JSON.parse(last_response.body)
-    else
-      last_response.body
-    end
+    JSON.load(last_response.body)
   end
 
   def api_get(url, expect_status: 200)
     get url
 
     expect(last_response.status).to eq(expect_status), last_response.errors
+    expect(last_response.content_type).to eq 'application/json'
 
-    if last_response.content_type == 'application/json'
-      JSON.parse(last_response.body)
-    else
-      last_response.body
-    end
+    JSON.load(last_response.body)
   end
 
   describe '/Plugin.Activate', :etcd => true do
@@ -74,9 +68,17 @@ describe IpamPlugin do
 
   describe '/IpamDriver.RequestPool' do
     it 'returns 400 on invalid JSON' do
-      data = api_post '/Plugin.Activate', 'invalid', expect_status: 400
+      post '/Plugin.Activate', 'invalid'
 
-      expect(data).to match(/^JSON parse error: \d*: unexpected token at '\"invalid\"'$/)
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to match(/^Invalid request body JSON::ParserError: \d+: unexpected token at 'invalid'$/)
+    end
+
+    it 'returns 400 on invalid data' do
+      post '/Plugin.Activate', 'true'
+
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to match(/^Invalid request body JSON::ParserError: \d+: unexpected token at 'true'$/)
     end
 
     it 'returns 400 on missing network option' do

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -538,10 +538,10 @@ describe IpamPlugin do
         expect(data).to eq({ })
 
         expect(etcd_server).to be_modified
-        expect(etcd_server.logs).to eq [
+        expect(etcd_server.logs).to contain_exactly( # ordering is undefined
           [:delete, '/kontena/ipam/addresses/test1/10.80.1.100'],
           [:delete, '/kontena/ipam/addresses/test1/10.80.1.111'],
-        ]
+        )
         expect(etcd_server.nodes).to eq({
           '/kontena/ipam/subnets/10.80.1.0' => { 'address' => '10.80.1.0/24' },
           '/kontena/ipam/pools/test1' => { 'subnet' => '10.80.1.0/24', 'gateway' => '10.80.1.1/24' },

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -78,7 +78,9 @@ describe IpamPlugin do
       post '/Plugin.Activate', 'true'
 
       expect(last_response.status).to eq(400)
-      expect(last_response.body).to match(/^Invalid request body JSON::ParserError: \d+: unexpected token at 'true'$/)
+
+      # this behaves differently on ruby json 1.8.3 vs 2.0.2
+      expect(last_response.body).to match(/^Invalid request body (JSON::ParserError: \d+: unexpected token at 'true'|TypeError: no implicit conversion of true into Hash)$/)
     end
 
     it 'returns 400 on missing network option' do

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -20,12 +20,14 @@ describe IpamPlugin do
     subject
   end
 
-  def api_post(url, params = {})
+  def api_post(url, params = {}, expect_status: 200)
     if params.nil?
       post url
     else
       post url, params.to_json, { 'CONTENT_TYPE' => 'application/json' }
     end
+
+    expect(last_response.status).to eq(expect_status), last_response.errors
 
     if last_response.content_type == 'application/json'
       JSON.parse(last_response.body)
@@ -34,8 +36,10 @@ describe IpamPlugin do
     end
   end
 
-  def api_get(url)
+  def api_get(url, expect_status: 200)
     get url
+
+    expect(last_response.status).to eq(expect_status), last_response.errors
 
     if last_response.content_type == 'application/json'
       JSON.parse(last_response.body)
@@ -64,32 +68,25 @@ describe IpamPlugin do
     it 'does not require request replay' do
       data = api_post '/IpamDriver.GetCapabilities', nil
 
-      expect(last_response).to be_ok
       expect(data['RequiresMACAddress']).to be_falsey
     end
   end
 
   describe '/IpamDriver.RequestPool' do
     it 'returns 400 on invalid JSON' do
-      data = api_post '/Plugin.Activate', 'invalid'
-
-      expect(last_response.status).to eq(400), last_response.errors
+      data = api_post '/Plugin.Activate', 'invalid', expect_status: 400
 
       expect(data).to match(/^JSON parse error: \d*: unexpected token at '\"invalid\"'$/)
     end
 
     it 'returns 400 on missing network option' do
-      data = api_post '/IpamDriver.RequestPool', {}
-
-      expect(last_response.status).to eq(400), last_response.errors
+      data = api_post '/IpamDriver.RequestPool', {}, expect_status: 400
 
       expect(data).to eq('Error' => "Network can't be nil")
     end
 
     it 'returns 400 on invalid pool' do
-      data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test'}, 'Pool' => 'xxx' }
-
-      expect(last_response.status).to eq(400), last_response.errors
+      data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test'}, 'Pool' => 'xxx' }, expect_status: 400
 
       expect(data).to eq('Error' => "Subnet is invalid")
     end
@@ -98,7 +95,6 @@ describe IpamPlugin do
       it 'creates a new dynamic pool with only the required parameters' do
         data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test'} }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq('PoolID' => 'test', 'Pool' => '10.80.0.0/24', 'Data' => {'com.docker.network.gateway' => '10.80.0.1/24'})
 
         expect(etcd_server).to be_modified
@@ -113,7 +109,6 @@ describe IpamPlugin do
       it 'creates a new dynamic pool with empty parameter values' do
         data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test'}, 'Pool' => '', 'SubPool' => ''}
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq('PoolID' => 'test', 'Pool' => '10.80.0.0/24', 'Data' => {'com.docker.network.gateway' => '10.80.0.1/24'})
 
         expect(etcd_server).to be_modified
@@ -128,7 +123,6 @@ describe IpamPlugin do
       it 'creates a new static pool using the given pool' do
         data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'kontena'}, 'Pool' => '10.81.0.0/16'}
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq('PoolID' => 'kontena', 'Pool' => '10.81.0.0/16', 'Data' => {'com.docker.network.gateway' => '10.81.0.1/16'})
 
         expect(etcd_server).to be_modified
@@ -143,7 +137,6 @@ describe IpamPlugin do
       it 'creates a new static pool using the given iprange' do
         data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'kontena'}, 'Pool' => '10.81.0.0/16', 'SubPool' => '10.81.127.0/17'}
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq('PoolID' => 'kontena', 'Pool' => '10.81.0.0/16', 'Data' => {'com.docker.network.gateway' => '10.81.0.1/16'})
 
         expect(etcd_server).to be_modified
@@ -168,7 +161,6 @@ describe IpamPlugin do
       it 'gets the existing pool' do
         data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test1'} }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq('PoolID' => 'test1', 'Pool' => '10.80.0.0/24', 'Data' => {'com.docker.network.gateway' => '10.80.0.1/24'})
 
         expect(etcd_server).to be_modified
@@ -183,7 +175,6 @@ describe IpamPlugin do
       it 'allocates dynamic addresses to avoid reservations' do
         data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test2'} }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq('PoolID' => 'test2', 'Pool' => '10.80.1.0/24', 'Data' => {'com.docker.network.gateway' => '10.80.1.1/24'})
 
         expect(etcd_server).to be_modified
@@ -199,18 +190,18 @@ describe IpamPlugin do
       end
 
       it 'fails on a configuration conflict' do
-        data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test1'}, 'Pool' => '10.80.1.0/24' }
+        data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test1'}, 'Pool' => '10.80.1.0/24' },
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data).to eq('Error' => "pool test1 exists with subnet 10.80.0.0, requested 10.80.1.0")
 
         expect(etcd_server).to_not be_modified
       end
 
       it 'fails on a subnet conflict' do
-        data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test2'}, 'Pool' => '10.64.0.0/10' }
+        data = api_post '/IpamDriver.RequestPool', { 'Options' => { 'network' => 'test2'}, 'Pool' => '10.64.0.0/10' },
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data).to eq('Error' => "10.64.0.0 conflict: Conflict with network 10.80.0.0/24")
 
         expect(etcd_server).to be_modified
@@ -230,9 +221,9 @@ describe IpamPlugin do
   describe '/IpamDriver.RequestAddress' do
     context 'with etcd being empty', :etcd => true do
       it 'fails for a nonexistant pool' do
-        data = api_post '/IpamDriver.RequestAddress', { 'PoolID' => 'test'}
+        data = api_post '/IpamDriver.RequestAddress', { 'PoolID' => 'test'},
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data).to eq('Error' => "Pool not found: test")
 
         expect(etcd_server).to_not be_modified
@@ -251,7 +242,6 @@ describe IpamPlugin do
       it 'allocates a dynamic address' do
         data = api_post '/IpamDriver.RequestAddress', { 'PoolID' => 'test' }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data.keys).to eq ['Address', 'Data']
 
         addr = IPAddr.new(data['Address'])
@@ -268,7 +258,6 @@ describe IpamPlugin do
       it 'allocates a static adress' do
         data = api_post '/IpamDriver.RequestAddress', { 'PoolID' => 'test', 'Address' => '10.80.0.1'}
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq('Address' => '10.80.0.1/24', 'Data' => {})
 
         expect(etcd_server).to be_modified
@@ -291,9 +280,9 @@ describe IpamPlugin do
       end
 
       it 'conflicts on an existing static adress' do
-        data = api_post '/IpamDriver.RequestAddress', { 'PoolID' => 'test', 'Address' => '10.80.0.1'}
+        data = api_post '/IpamDriver.RequestAddress', { 'PoolID' => 'test', 'Address' => '10.80.0.1'},
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data['Error']).to match(%r{Allocation conflict for address=10.80.0.1: Create conflict with /kontena/ipam/addresses/test/10.80.0.1@\d+: Key already exists})
 
         expect(etcd_server).to_not be_modified, etcd_server.logs.inspect
@@ -302,7 +291,6 @@ describe IpamPlugin do
       it 'allocates a dynamic adress' do
         data = api_post '/IpamDriver.RequestAddress', { 'PoolID' => 'test' }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data.keys).to eq ['Address', 'Data']
 
         addr = IPAddr.new(data['Address'])
@@ -321,7 +309,6 @@ describe IpamPlugin do
       it 'allocates a static adress' do
         data = api_post '/IpamDriver.RequestAddress', { 'PoolID' => 'test', 'Address' => '10.80.0.2'}
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq('Address' => '10.80.0.2/24', 'Data' => {})
 
         expect(etcd_server).to be_modified
@@ -348,45 +335,45 @@ describe IpamPlugin do
       end
 
       it 'rejects a missing pool param' do
-        data = api_post '/IpamDriver.ReleaseAddress', { 'Address' => '10.80.2.100'}
+        data = api_post '/IpamDriver.ReleaseAddress', { 'Address' => '10.80.2.100'},
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data).to eq('Error' => "Pool can't be nil")
 
         expect(etcd_server).to_not be_modified
       end
 
       it 'rejects a missing address param' do
-        data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test' }
+        data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test' },
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data).to eq('Error' => "Address can't be nil")
 
         expect(etcd_server).to_not be_modified
       end
 
       it 'rejects an invalid address' do
-        data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test2', 'Address' => '10.80.2.265'}
+        data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test2', 'Address' => '10.80.2.265'},
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data).to eq('Error' => "Address is invalid")
 
         expect(etcd_server).to_not be_modified
       end
 
       it 'rejects for a nonexistant pool' do
-        data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test2', 'Address' => '10.80.2.100'}
+        data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test2', 'Address' => '10.80.2.100'},
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data).to eq('Error' => "AddressPool not found: test2")
 
         expect(etcd_server).to_not be_modified
       end
 
       it 'rejects an address outside of the pool' do
-        data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test', 'Address' => '10.80.2.100'}
+        data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test', 'Address' => '10.80.2.100'},
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data).to eq('Error' => "Address 10.80.2.100 outside of pool subnet 10.80.0.0")
 
         expect(etcd_server).to_not be_modified
@@ -395,7 +382,6 @@ describe IpamPlugin do
       it 'ignores release for a nonexistant address' do
         data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test', 'Address' => '10.80.0.2'}
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq({})
 
         expect(etcd_server).to_not be_modified
@@ -404,7 +390,6 @@ describe IpamPlugin do
       it 'releases one of the addresses' do
         data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test', 'Address' => '10.80.0.100'}
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq({})
 
         expect(etcd_server).to be_modified
@@ -418,7 +403,6 @@ describe IpamPlugin do
       it 'release of gateway has no effect' do
         data = api_post '/IpamDriver.ReleaseAddress', { 'PoolID' => 'test', 'Address' => '10.80.0.1'}
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq({})
 
         expect(etcd_server).to_not be_modified
@@ -444,9 +428,9 @@ describe IpamPlugin do
       end
 
       it 'rejects for a nonexistant pool' do
-        data = api_post '/IpamDriver.ReleasePool', { 'PoolID' => 'test' }
+        data = api_post '/IpamDriver.ReleasePool', { 'PoolID' => 'test' },
+          expect_status: 400
 
-        expect(last_response.status).to eq(400), last_response.errors
         expect(data).to eq('Error' => "AddressPool not found: test")
 
         expect(etcd_server).to_not be_modified
@@ -455,7 +439,6 @@ describe IpamPlugin do
       it 'releases the pool but leaves it in use on a different node' do
         data = api_post '/IpamDriver.ReleasePool', { 'PoolID' => 'test1' }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq({})
 
         expect(etcd_server).to be_modified
@@ -475,7 +458,6 @@ describe IpamPlugin do
       it 'releases the pool and deletes it if not used on another node' do
         data = api_post '/IpamDriver.ReleasePool', { 'PoolID' => 'test2' }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq({})
 
         expect(etcd_server).to be_modified
@@ -495,7 +477,6 @@ describe IpamPlugin do
     it "Returns the current etcd index", :etcd => true do
       data = api_get '/KontenaIPAM.Cleanup'
 
-      expect(last_response).to be_ok, last_response.errors
       expect(data).to eq({ 'EtcdIndex' => etcd_server.etcd_index })
     end
   end
@@ -506,9 +487,8 @@ describe IpamPlugin do
         'EtcdIndex' => 0,
         'PoolID'    => 'test1',
         'Addreses'  => [ '127.0.0.1' ],
-      }
+      }, expect_status: 400
 
-      expect(last_response.status).to eq(400), last_response.errors
       expect(data['Error']).to match(%r{Addresses can't be nil})
     end
 
@@ -534,7 +514,6 @@ describe IpamPlugin do
           'Addresses' => [],
         }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq({ })
 
         expect(etcd_server).to be_modified
@@ -560,7 +539,6 @@ describe IpamPlugin do
           ],
         }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq({ })
 
         expect(etcd_server).to be_modified
@@ -582,7 +560,6 @@ describe IpamPlugin do
         # request address
         req_data = api_post '/IpamDriver.RequestAddress', { 'PoolID' => 'test1', 'Address' => '10.80.1.112'}
 
-        expect(last_response).to be_ok, last_response.errors
         expect(req_data).to eq('Address' => '10.80.1.112/24', 'Data' => {})
 
         # cleanup
@@ -594,7 +571,6 @@ describe IpamPlugin do
           ],
         }
 
-        expect(last_response).to be_ok, last_response.errors
         expect(data).to eq({ })
 
         # verify

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -96,9 +96,10 @@ describe Policy do
           ipaddr = subject.allocate_address(pool)
 
           expect(ipaddr).to_not be_nil
-          expect(ipaddr).to be > IPAddr.new('10.81.0.1')
-          expect(ipaddr).to be >= IPAddr.new('10.81.128.0')
-          expect(ipaddr).to be < IPAddr.new('10.81.128.100')
+          expect(ipaddr.length).to eq 16
+          expect(ipaddr).to be > IPAddr.new('10.81.0.1/16')
+          expect(ipaddr).to be >= IPAddr.new('10.81.128.0/16')
+          expect(ipaddr).to be < IPAddr.new('10.81.128.100/16')
         end
 
         it 'allocates different addresses' do


### PR DESCRIPTION
* Return HTTP 400 on any invalid request body, such as a string, not just JSON parser errors
* Fix cleanup specs ordering
* Fix policy specs edge case on IPAddr cmp without netmask
* Fix invalid request json specs